### PR TITLE
Relax go.mod go version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+- 1.11.x
+- 1.10.x
+- 1.9.x
+- 1.8.x
+
+script: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/tilinna/clock
 
-go 1.12
+go 1.8


### PR DESCRIPTION
`tilinna/clock` is a dep of another package we are using. In `go.mod` `tilinna/clock` requires Go 1.12. 

Go 1.12 is not officially released yet. I checked go versions 1.11, 1.10, 1.9, 1.8 and this package just works fine with all the listed versions. 

This PR relaxes the Go version constraint in go.mod and also adds a travis.yml file to run CI tests.